### PR TITLE
fix: remove empty underline on links on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,7 @@ permalink: /
     <div class="col-xs-12 col-sm-2 col-lg-1 px-3 px-sm-0 mt-2 mt-sm-3 text-sm-center"><a
         href="{{ linkInfo[1].href }}"{% if site.ga %}
         onclick="trackOutboundLink('{{ linkInfo[1].name }}', '{{ linkInfo[1].href }}'); return false;"
-        {% endif %}><i class="{{ linkInfo[1].icon }}"></i>
-        <span class="d-inline d-sm-none">{{ linkInfo[1].name }}</span></a></div>
+        {% endif %}><i class="{{ linkInfo[1].icon }}"></i><span class="d-inline d-sm-none">{{ linkInfo[1].name }}</span></a></div>
 {% endif %}{% endfor %}{% endfor %}
 </div>
 


### PR DESCRIPTION
* this change gets rid of the underline on links if page viewed on small screens